### PR TITLE
Stop uncheck-only updates.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sync_issues (0.0.1a1)
+    sync_issues (0.0.1)
       docopt (~> 0.5)
       octokit (~> 4.2)
       safe_yaml (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sync_issues (0.0.1)
+    sync_issues (0.1.0)
       docopt (~> 0.5)
       octokit (~> 4.2)
       safe_yaml (~> 1.0)

--- a/lib/sync_issues/comparison.rb
+++ b/lib/sync_issues/comparison.rb
@@ -1,0 +1,37 @@
+require_relative 'error'
+
+module SyncIssues
+  # Comparison represents differences between Issues (local and GitHub)
+  class Comparison
+    attr_reader :changed, :content, :title
+
+    def initialize(issue, github_issue)
+      @changed = []
+      @content = github_issue.body
+      @title = github_issue.title
+      compare(issue, github_issue)
+    end
+
+    def changed?
+      !@changed.empty?
+    end
+
+    private
+
+    def compare(issue, github_issue)
+      unless issue.new_title.nil?
+        @changed << 'title'
+        @title = issue.new_title
+      end
+      unless content_matches?(issue.content, github_issue.body)
+        @changed << 'body'
+        @content = issue.content
+      end
+    end
+
+    def content_matches?(first, second)
+      second.delete!("\r")
+      first.gsub(/\[x\]/, '[ ]') == second.gsub(/\[x\]/, '[ ]')
+    end
+  end
+end

--- a/lib/sync_issues/github.rb
+++ b/lib/sync_issues/github.rb
@@ -25,9 +25,8 @@ module SyncIssues
       raise Error, 'repository not found'
     end
 
-    def update_issue(repository, github_issue, issue)
-      @client.update_issue(repository.full_name, github_issue.number,
-                           issue.new_title || issue.title, issue.content)
+    def update_issue(repository, issue_number, title, content)
+      @client.update_issue(repository.full_name, issue_number, title, content)
     end
 
     private

--- a/lib/sync_issues/synchronizer.rb
+++ b/lib/sync_issues/synchronizer.rb
@@ -1,3 +1,4 @@
+require_relative 'comparison'
 require_relative 'error'
 require_relative 'parser'
 require 'English'
@@ -85,13 +86,13 @@ module SyncIssues
     end
 
     def update_issue(repository, issue, github_issue)
-      changed = []
-      changed << 'title' unless issue.new_title.nil?
-      changed << 'body' unless issue.content == github_issue.body
-      return if changed.empty?
+      comparison = Comparison.new(issue, github_issue)
+      return unless comparison.changed?
 
-      puts "Updating #{changed.join(', ')} on ##{github_issue.number}"
-      SyncIssues.github.update_issue(repository, github_issue, issue)
+      changed = comparison.changed.join(', ')
+      puts "Updating #{changed} on ##{github_issue.number}"
+      SyncIssues.github.update_issue(repository, github_issue.number,
+                                     comparison.title, comparison.content)
     end
   end
 end

--- a/lib/sync_issues/version.rb
+++ b/lib/sync_issues/version.rb
@@ -1,4 +1,4 @@
 # SyncIssues
 module SyncIssues
-  VERSION = '0.0.1'.freeze
+  VERSION = '0.1.0'.freeze
 end

--- a/test/sync_issues/comparison_test.rb
+++ b/test/sync_issues/comparison_test.rb
@@ -1,0 +1,49 @@
+require 'minitest/autorun'
+require 'mocha'
+require 'mocha/mini_test'
+require 'sync_issues'
+
+# Test SycnIssues::Comparison
+class ComparisonTest < MiniTest::Test
+  def test_changed_title
+    issue, github = test_stubs new_title: 'Something'
+    comparison = SyncIssues::Comparison.new(issue, github)
+    assert comparison.changed?
+    assert_equal ['title'], comparison.changed
+  end
+
+  def test_changed_body
+    issue, github = test_stubs gh_content: 'Some other content'
+    comparison = SyncIssues::Comparison.new(issue, github)
+    assert comparison.changed?
+    assert_equal ['body'], comparison.changed
+    assert_equal issue.title, comparison.title
+    assert_equal issue.content, comparison.content
+  end
+
+  def test_changed_nothing
+    issue, github = test_stubs
+    assert !SyncIssues::Comparison.new(issue, github).changed?
+  end
+
+  def test_changed_nothing_but_markdown_checkbox
+    issue, github = test_stubs(content: "- [ ] Some content\n",
+                               gh_content: "- [x] Some content\r\n")
+
+    comparison = SyncIssues::Comparison.new(issue, github)
+    assert !comparison.changed?
+    assert_equal github.title, comparison.title
+    assert_equal github.body, comparison.content
+  end
+
+  private
+
+  def test_stubs(content: 'Some content', title: 'GitHub', new_title: nil,
+                 gh_content: 'Some content', gh_title: 'GitHub')
+    issue = mock
+    github = mock
+    issue.stubs(content: content, title: title, new_title: new_title)
+    github.stubs(body: gh_content, title: gh_title)
+    [issue, github]
+  end
+end

--- a/test/sync_issues/issue_test.rb
+++ b/test/sync_issues/issue_test.rb
@@ -1,6 +1,4 @@
 require 'minitest/autorun'
-require 'mocha'
-require 'mocha/mini_test'
 require 'sync_issues'
 
 # Test SycnIssues::Issue


### PR DESCRIPTION
This pull request ignores changes to markdown checkbox statuses. That is if someone only checks boxes on a github issue and no other changes were made, then the issue will not be updated.

Previously running sync_issues would always update the body of the issue to uncheck existing checkboxes, and that is annoying.
