### PR TITLE
Add support for synchronizing labels.

### DIFF
--- a/lib/sync_issues/command.rb
+++ b/lib/sync_issues/command.rb
@@ -18,6 +18,7 @@ module SyncIssues
     Options:
       -h --help       Output this help information.
       -u --update     Only update existing issues.
+      --labels FILE   A yaml file listing labels that are to be available.
       --no-assignees  Do not synchronize assignees.
       --version       Output the sync_issues version (#{VERSION}).
     DOC
@@ -46,9 +47,17 @@ module SyncIssues
 
     def handle_args(options)
       SyncIssues.synchronizer(options['DIRECTORY'], options['REPOSITORY'],
+                              label_yaml: read_file(options['--labels']),
                               sync_assignees: !options['--no-assignees'],
                               update_only: options['--update']).run
       @exit_status
+    end
+
+    def read_file(filename)
+      return nil if filename.nil?
+      File.read(filename)
+    rescue Errno::ENOENT
+      raise Error, "not found: #{filename}"
     end
   end
 end

--- a/lib/sync_issues/github.rb
+++ b/lib/sync_issues/github.rb
@@ -5,6 +5,8 @@ require 'safe_yaml/load'
 module SyncIssues
   # GitHub is responsible access to GitHub's API
   class GitHub
+    attr_reader :client
+
     def initialize
       @client = Octokit::Client.new access_token: token
       @client.auto_paginate = true
@@ -19,6 +21,10 @@ module SyncIssues
 
     def issues(repository)
       @client.issues(repository.full_name, state: :all)
+    end
+
+    def labels(repository)
+      @client.labels(repository.full_name)
     end
 
     def repository(repository_name)

--- a/lib/sync_issues/label_sync.rb
+++ b/lib/sync_issues/label_sync.rb
@@ -1,0 +1,93 @@
+require_relative 'error'
+require 'safe_yaml/load'
+
+module SyncIssues
+  # Synchronizer is responsible for the actual synchronization.
+  class LabelSync
+    attr_reader :do_work, :keep_existing, :labels
+
+    def initialize(github, file_yaml)
+      @github = github
+      @labels = @keep_existing = nil
+      @do_work = file_yaml.nil? ? false : parse_yaml(file_yaml)
+    end
+
+    def synchronize(repository)
+      return unless @do_work
+      existing = existing_labels(repository)
+      make_changes(existing, repository)
+    end
+
+    private
+
+    def add_labels(labels, repository)
+      labels.each do |label, color|
+        puts "\tadd label: #{label}"
+        @github.client.add_label(repository.full_name, label, color)
+      end
+    end
+
+    def delete_labels(labels, repository)
+      labels.each do |label, _|
+        if @keep_existing
+          puts "\tkeeping label: #{label}"
+        else
+          puts "\tdelete label: #{label}"
+          @github.client.delete_label!(repository.full_name, label)
+        end
+      end
+    end
+
+    def make_changes(existing, repository)
+      changes = { add: [], update: [] }
+      @labels.each do |label, color|
+        if existing.include?(label)
+          changes[:update] << [label, color] unless existing[label] == color
+          existing.delete(label)
+        else
+          changes[:add] << [label, color]
+        end
+      end
+
+      add_labels(changes[:add], repository)
+      update_labels(changes[:update], repository)
+      delete_labels(existing, repository)
+    rescue Octokit::UnprocessableEntity => exc
+      raise unless exc.errors.count == 1 && exc.errors[0][:resource] == 'Label'
+      error = exc.errors[0]
+      raise Error, "Label error: #{error[:code]} #{error[:field]}"
+    end
+
+    def existing_labels(repository)
+      Hash[@github.labels(repository).map do |label|
+        [label[:name], label[:color]]
+      end]
+    end
+
+    def parse_yaml(yaml)
+      data = SafeYAML.load(yaml)
+      return nil unless data
+      if data.include?('labels') && data['labels'].is_a?(Hash)
+        @labels = Hash[data['labels'].map do |label, color|
+          if color.is_a?(Integer)
+            raise Error, 'Label error: add quotes around numeric color values'
+          end
+          [label, color.to_s.downcase]
+        end]
+      else
+        @labels = {}
+      end
+      @keep_existing = data['keep_existing'] != false
+      @labels.size > 0 || !@keep_existing
+    rescue Psych::SyntaxError
+      raise ParseError, 'invalid label yaml file'
+    end
+
+    def update_labels(labels, repository)
+      labels.each do |label, color|
+        puts "\tupdate label: #{label}"
+        @github.client.update_label(repository.full_name, label, color: color)
+      end
+    end
+  end
+end

--- a/test/sync_issues/label_sync_test.rb
+++ b/test/sync_issues/label_sync_test.rb
@@ -1,0 +1,72 @@
+require 'minitest/autorun'
+require 'sync_issues'
+
+# Test SyncIssues::LabelSync
+class LabelSyncTest < MiniTest::Test
+  def test_yaml_nothing_of_use
+    [nil, '', 'unused: foo', 'keep_existing: flse', # typo should == true
+     'keep_existing: true'].each do |yaml|
+      label_sync = SyncIssues::LabelSync.new(nil, yaml)
+      assert !label_sync.do_work
+    end
+  end
+
+  def test_yaml_delete_only
+    label_sync = SyncIssues::LabelSync.new(nil, 'keep_existing: false')
+    assert label_sync.do_work
+    assert !label_sync.keep_existing
+    assert_equal({}, label_sync.labels)
+  end
+
+  def test_yaml_invalid
+    SyncIssues::LabelSync.new(nil, 'a: b: c')
+    assert false
+  rescue SyncIssues::ParseError => exc
+    assert_equal 'invalid label yaml file', exc.message
+  end
+
+  def test_yaml_label_color_is_a_number
+    SyncIssues::LabelSync.new(nil, "labels:\n  bad: 000000")
+    assert false
+  rescue SyncIssues::Error => exc
+    assert_equal('Label error: add quotes around numeric color values',
+                 exc.message)
+  end
+
+  def test_yaml_labels_is_not_a_hash
+    label_sync = SyncIssues::LabelSync.new(
+      nil, "keep_existing: false\nlabels: a")
+    assert label_sync.do_work
+    assert !label_sync.keep_existing
+    assert_equal({}, label_sync.labels)
+  end
+
+  def test_yaml_labels_only
+    label_sync = SyncIssues::LabelSync.new(nil, "labels:\n  merged: '009800'")
+    assert label_sync.do_work
+    assert label_sync.keep_existing
+    assert_equal({ 'merged' => '009800' }, label_sync.labels)
+  end
+
+  def test_yaml_nil
+    label_sync = SyncIssues::LabelSync.new(nil, nil)
+    assert !label_sync.do_work
+    assert label_sync.keep_existing.nil?
+    assert label_sync.labels.nil?
+  end
+
+  def test_yaml_valid
+    label_sync = SyncIssues::LabelSync.new(
+      nil, <<-YML
+      keep_existing: false
+      labels:
+        in progress: FF00FF
+        unstarted: '000088'
+    YML
+    )
+    assert label_sync.do_work
+    assert !label_sync.keep_existing
+    assert_equal({ 'in progress' => 'ff00ff',
+                   'unstarted' => '000088' }, label_sync.labels)
+  end
+end

--- a/test/sync_issues/parser_test.rb
+++ b/test/sync_issues/parser_test.rb
@@ -3,7 +3,7 @@ require 'mocha'
 require 'mocha/mini_test'
 require 'sync_issues'
 
-# Test SycnIssues::Parser
+# Test SyncIssues::Parser
 class ParserTest < MiniTest::Test
   MD_CONTENT = "Markdown Content\n"
 


### PR DESCRIPTION
This addition does not yet add labels to issues, but merely synchronizes the labels available in the repository.
